### PR TITLE
don't replace collision polies with empty arrays on noclip

### DIFF
--- a/scripts/wedit/controller.lua
+++ b/scripts/wedit/controller.lua
@@ -316,8 +316,6 @@ function controller.update(args)
     mcontroller.controlParameters({
       gravityEnabled = false,
       collisionEnabled = false,
-      standingPoly = {},
-      crouchingPoly = {},
       mass = 0,
       runSpeed = 0,
       walkSpeed = 0,

--- a/scripts/wedit/controller.lua
+++ b/scripts/wedit/controller.lua
@@ -316,6 +316,8 @@ function controller.update(args)
     mcontroller.controlParameters({
       gravityEnabled = false,
       collisionEnabled = false,
+      standingPoly = {{0,0}},
+      crouchingPoly = {{0,0}},
       mass = 0,
       runSpeed = 0,
       walkSpeed = 0,


### PR DESCRIPTION
Doing this messes up a *lot* of things as entity queries now find you if your bounding box (which is quite large) is within the query range. This results in noclipping players triggering pressure plates and automatic doors when just in the general area of them.

Instead, replace it with just a point. Collision is already disabled (by collisionEnabled = false), and a point poly is still not visible (assuming that was the intent of an empty poly) but doesn't cause you to be an entity query magnet.

(this may have caused me immense pain in the past)